### PR TITLE
implement remark plugin to strip out truncation marker

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -2,6 +2,9 @@ import {themes as prismThemes} from 'prism-react-renderer';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 import copyStylesPlugin from './src/buildUtils/docusaurus/postBuild/copyStylesPlugin';
+import removeTruncateMarker from './src/buildUtils/docusaurus/remark/removeTruncateMarker';
+
+const  truncateRegex: RegExp = /\s*TRUNCATE_HERE\s*/;
 
 const config: Config = {
   title: 'Iain Davis',
@@ -51,7 +54,17 @@ const config: Config = {
             description: 'A Blog where I will document what I am working on and looking forward to as I develop my personal website',
             copyright: `Copyright © ${new Date().getFullYear()} Iain S. Davis. Built with Docusaurus.`,
           },
-          truncateMarker: /\s*TRUNCATE_HERE\s*/,
+          truncateMarker: truncateRegex,
+          remarkPlugins: [
+            /*
+            [
+              removeTruncateMarker,
+              {
+                regex: truncateRegex,
+              },
+            ]
+              */
+              ],
           authorsMapPath: 'authors.yml',
           authorsBasePath: 'authors',
           showReadingTime: true,

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "css-loader": "^7.1.2",
     "storybook": "^8.2.9",
     "style-loader": "^4.0.0",
-    "typescript": "~5.2.2"
+    "typescript": "~5.2.2",
+    "unist-util-remove": "^4.0.0"
   },
   "browserslist": {
     "production": [

--- a/src/buildUtils/docusaurus/remark/removeTruncateMarker.ts
+++ b/src/buildUtils/docusaurus/remark/removeTruncateMarker.ts
@@ -1,0 +1,11 @@
+// removeTruncateMarker.mjs
+import { visit } from 'unist-util-visit';
+
+const removeTruncateMarker = ({ regex }) => (tree) => {
+    visit(tree, 'text', (node, index, parent) => {
+        regex.test(node?.value) && parent?.children?.splice(index, 1);
+    });
+}
+
+export default removeTruncateMarker;
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -10191,6 +10191,15 @@ unist-util-remove@^2.0.0:
   dependencies:
     unist-util-is "^4.0.0"
 
+unist-util-remove@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-remove/-/unist-util-remove-4.0.0.tgz#94b7d6bbd24e42d2f841e947ed087be5c82b222e"
+  integrity sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-is "^6.0.0"
+    unist-util-visit-parents "^6.0.0"
+
 unist-util-stringify-position@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz#cce3bfa1cdf85ba7375d1d5b17bdc4cada9bd9da"


### PR DESCRIPTION
## [JIRA | IDAVIS-64](https://iaindavis-dev.atlassian.net/browse/IDAVIS-64)

### Problem Statement
The text 'TRUNCATE HERE', used to indicate the end of the summary portion of a blog post, appears in the final rendered blog post.

### Likely Cause
The custom truncation token (`TRUNCATE_HERE`) I introduced in a previous change is not something that Docusaurus hides by default (_e.g._ an XML comment like the default setting uses)

 No auto-hidden token renders with correct syntax highlighting in VS Code.

### Proposed Solution
Introduce a Remark plugin to manually detect and strip out the new token.

| Before | After |
| -------|------|
| ![screen capture showing unwanted TRUNCATE_HERE token in blog output](https://github.com/user-attachments/assets/700bc914-9859-449a-ad92-6a57f339bd1b "Before") | ![screen capture showing blog output without unwanted TRUNCATE_HERE token](https://github.com/user-attachments/assets/c0d95687-0065-4742-b517-dabf42f55fce) |
