### PR TITLE
add more socials

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -8,3 +8,5 @@ iain:
   socials:
     github: IainDavis
     linkedin: iaindavis-dev
+    stackoverflow: https://stackoverflow.com/users/11380293/iaindavis-dev
+    reddit: https://www.reddit.com/user/IainDavis-dev/


### PR DESCRIPTION
### Description
Adding 'Stack Overflow' and 'Reddit' to socials.

Note: Docusaurus doesn't support Reddit out of the box, so I'll have to manually add the icon later.