### PR TITLE
restrict 'copy-text-to-clipboard' to versions below v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,9 @@
     "typescript": "~5.2.2",
     "unist-util-remove": "^4.0.0"
   },
+  "resolutions": {
+    "copy-text-to-clipboard": "2.2.0"
+  },
   "browserslist": {
     "production": [
       ">0.5%",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4803,10 +4803,10 @@ cookie@0.6.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.6.0.tgz#2798b04b071b0ecbff0dbb62a505a8efa4e19051"
   integrity sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==
 
-copy-text-to-clipboard@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.0.tgz#0202b2d9bdae30a49a53f898626dcc3b49ad960b"
-  integrity sha512-RnJFp1XR/LOBDckxTib5Qjr/PMfkatD0MUCQgdpqS8MdKiNUzBjAQBEN6oUy+jW7LI93BBG3DtMB2KOOKpGs2Q==
+copy-text-to-clipboard@2.0.1, copy-text-to-clipboard@^3.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/copy-text-to-clipboard/-/copy-text-to-clipboard-2.2.0.tgz#329dd6daf8c42034c763ace567418401764579ae"
+  integrity sha512-WRvoIdnTs1rgPMkgA2pUOa/M4Enh2uzCwdKsOMYNAJiz/4ZvEJgmbF4OmninPmlFdAWisfeh0tH+Cpf7ni3RqQ==
 
 copy-webpack-plugin@^11.0.0:
   version "11.0.0"


### PR DESCRIPTION
## Problem Statement
Viewing docusaurus content in the browser produces an error, if that content includes the `CodeBlock` component (explicitly, or inferred from MDX)

## Likely Cause
Recently upgraded Docusaurus dependencies. Docusaurus relies on `copy-text-to-clipboard` to enable the `CopyButton` component within the `CodeBlock` component. Upgrading docusaurus implicitly updated `copy-text-to-clipboard` to version ^3. Versions above 3 are ESModules, while versions below 3 relied on CommonJS.

## Proposed fix
Pin the version of `copy-text-to-clipboard` to versions before v3.